### PR TITLE
fix(wrapper): add error in xml tag

### DIFF
--- a/vast.go
+++ b/vast.go
@@ -163,7 +163,7 @@ type Wrapper struct {
 	Impressions []Impression `xml:"Impression"`
 	// A URI representing an error-tracking pixel; this element can occur multiple
 	// times.
-	Errors []CDATAString `xml:",omitempty" json:",omitempty"`
+	Errors []CDATAString `xml:"Error,omitempty" json:"Error,omitempty"`
 	// The container for one or more <Creative> elements
 	Creatives []CreativeWrapper `xml:"Creatives>Creative"`
 	// XML node for custom extensions, as defined by the ad server. When used, a


### PR DESCRIPTION
Currently when we marshal an XML to the `VAST` struct the Wrapper does not correctly map the `Error` tag at the `Ad` level.
The `Wrapper` in the `VAST` struct expect to have `Errors` in the XML, it's not correct according to the IAB specification : https://iabtechlab.com/wp-content/uploads/2019/06/VAST_4.2_final_june26.pdf

![image](https://github.com/haxqer/vast/assets/7600006/a0b9d443-3e37-455b-9391-8456cae3f936)


The purpose of this PR is to fix the xml/json tag when marshalling/unmarshalling the `Wrapper` struct to xml or json (and the other way around)