### PR TITLE
fix: Add CDATA-Wrapped URI to VerificationParameters and Mezzanine struct

### DIFF
--- a/vast4.go
+++ b/vast4.go
@@ -49,9 +49,14 @@ type Verification struct {
 	TrackingEvents *TrackingEvents `xml:"TrackingEvents,omitempty"`
 	// <VerificationParameters> contains a CDATA-wrapped string intended for bootstrapping the verification code and providing metadata about the current impression.
 	// The format of the string is up to the individual vendor and should be passed along verbatim.
-	VerificationParameters string `xml:",omitempty"`
+	VerificationParameters *VerificationParameters `xml:",omitempty"`
 	// ad categories are used in creative separation and for compliance in certain programs
 	BlockedAdCategories []Category `xml:",omitempty"`
+}
+
+type VerificationParameters struct {
+	// CDATA-wrapped metadata string for the verification executable
+	URI string `xml:",cdata"`
 }
 
 // A container for the URI to the JavaScript file used to collect verification data.
@@ -96,6 +101,8 @@ type Mezzanine struct {
 	// Type of media file (2D / 3D / 360 / etc). Optional.
 	// Default value = 2D
 	MediaType string `xml:"mediaType,attr,omitempty" json:",omitempty"`
+	// A CDATA-wrapped URI to a raw, high-quality media file
+	URI string `xml:",cdata"`
 }
 
 type InteractiveCreativeFile struct {


### PR DESCRIPTION
`VerificationParameters` and `Mezzanine` should contain a CDATA-Wrapped URI per the specs.

- `VerificationParameters` field modified to include CDATA-Wrapped URI
- Added CDATA-Wrapped URI URI to `Mezzanine` struct

![image](https://github.com/user-attachments/assets/3c4e1756-097d-48ba-9f9b-9ae487400395)
![image](https://github.com/user-attachments/assets/e8c37d43-083a-41d2-ac32-826cb3d32a5b)
